### PR TITLE
Remove runtime import from lib/lib.go

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 


### PR DESCRIPTION
`go build` complained of an unused import statement in lib/lib.go for me. Removing "runtime" makes `acpush` build successfully.

(This is my first-ever pull request. Please let me know if you need more from me than what I have provided!)
